### PR TITLE
Handle situation where defineProperty does not exist

### DIFF
--- a/lib/middleware_stack.js
+++ b/lib/middleware_stack.js
@@ -30,6 +30,7 @@ MiddlewareStack.prototype._create = function (path, fn, options) {
       throw new Error("Handler with name '" + name + "' already exists.");
     }
     this._stack[name] = handler;
+    this._updateLength();
   }
 
   return handler;
@@ -45,6 +46,7 @@ MiddlewareStack.prototype.findByName = function (name) {
 MiddlewareStack.prototype.push = function (path, fn, options) {
   var handler = this._create(path, fn, options);
   this._stack.push(handler);
+  this._updateLength();
   return handler;
 };
 
@@ -81,6 +83,7 @@ MiddlewareStack.prototype.append = function (/* fn1, fn2, [f3, f4]... */) {
 MiddlewareStack.prototype.insertAt = function (index, path, fn, options) {
   var handler = this._create(path, fn, options);
   this._stack.splice(index, 0, handler);
+  this._updateLength();
   return this;
 };
 
@@ -126,6 +129,7 @@ MiddlewareStack.prototype.concat = function (/* stack1, stack2, */) {
   var clonedThisStack = EJSON.clone(this._stack);
   var clonedOtherStacks = _.map(_.toArray(arguments), function (s) { return EJSON.clone(s._stack); });
   ret._stack = concat.apply(clonedThisStack, clonedOtherStacks);
+  this._updateLength();
   return ret;
 };
 
@@ -184,6 +188,7 @@ MiddlewareStack.prototype.dispatch = function dispatch (url, context, done) {
   //XXX make this not an anonymous function or hard to read in the debugger
   var next = Meteor.bindEnvironment(function boundNext (err) {
     var handler = self._stack[index++];
+    self._updateLength();
 
     // reset the url
     context.url = context.request.url = context.originalUrl;
@@ -288,7 +293,16 @@ if (typeof Object.defineProperty === "function"){
     });
 }else{
     console.log("defineProperty is not supported in this browser @ MiddlewareStack.length.");
+    MiddlewareStack.prototype.length = 0;
+    MiddlewareStack.prototype._requiresLengthUpdate = true;
 }
+
+//A helper for compatibility in browsers without defineProperty support
+MiddlewareStack.prototype._updateLength = function(){
+    if(this._requiresLengthUpdate)
+        this.length = this._stack.length;
+};
+
 
 Iron = Iron || {};
 Iron.MiddlewareStack = MiddlewareStack;


### PR DESCRIPTION
In some older browsers (Awesomium, etc) Object.defineProperty does not exist. This breaks the entire app in these browsers. I've added a simple compatibility check before using the function. It might break some things internally down the road to not have the property defined, but it's better than nothing.
