### PR TITLE
Bugfix in MiddlewareStack.concat

### DIFF
--- a/lib/middleware_stack.js
+++ b/lib/middleware_stack.js
@@ -129,7 +129,7 @@ MiddlewareStack.prototype.concat = function (/* stack1, stack2, */) {
   var clonedThisStack = EJSON.clone(this._stack);
   var clonedOtherStacks = _.map(_.toArray(arguments), function (s) { return EJSON.clone(s._stack); });
   ret._stack = concat.apply(clonedThisStack, clonedOtherStacks);
-  this.length = ret._stack.length;
+  ret.length = ret._stack.length;
   return ret;
 };
 


### PR DESCRIPTION
Hi there,

I've been stepping through the entirety of the IR process trying to figure out, um, stuffs.  Doing so, I noticed a peculiarity -- when MiddlewareStacks are concatenated, there is a "length" member variable that doesn't get updated.  I'm assuming this is a bug and providing a PR.