### PR TITLE
Fix Iron Router with Meteor 1.2

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,7 +8,9 @@ Package.on_use(function (api) {
   api.versionsFrom('METEOR@0.9.2');
 
   api.use('underscore');
-  
+
+  api.use('ejson');
+
   api.use('iron:core@1.0.8');
   api.imply('iron:core');
 


### PR DESCRIPTION
Based on core changes for Meteor 1.2 this package now needs to .use ejson to avoid issues. 

More info at: https://forums.meteor.com/t/iron-router-not-working-with-meteor-1-2/10196