### PR TITLE
Remove name=>handler mapping from the stack.

### DIFF
--- a/lib/middleware_stack.js
+++ b/lib/middleware_stack.js
@@ -23,21 +23,7 @@ MiddlewareStack = function () {
 };
 
 MiddlewareStack.prototype._create = function (path, fn, options) {
-  var handler = new Handler(path, fn, options);
-  var name = handler.name;
-
-  if (name) {
-    if (_.has(this._stack, name)) {
-      throw new Error("Handler with name '" + name + "' already exists.");
-    }
-    this._stack[name] = handler;
-  }
-
-  return handler;
-};
-
-MiddlewareStack.prototype.findByName = function (name) {
-  return this._stack[name];
+  return new Handler(path, fn, options);
 };
 
 /**
@@ -88,40 +74,8 @@ MiddlewareStack.prototype.insertAt = function (index, path, fn, options) {
 };
 
 /**
- * Insert a handler before another named handler.
- */
-MiddlewareStack.prototype.insertBefore = function (name, path, fn, options) {
-  var beforeHandler;
-  var index;
-
-  if (!(beforeHandler = this._stack[name]))
-    throw new Error("Couldn't find a handler named '" + name + "' on the path stack");
-
-  index = _.indexOf(this._stack, beforeHandler);
-  this.insertAt(index, path, fn, options);
-  return this;
-};
-
-/**
- * Insert a handler after another named handler.
- *
- */
-MiddlewareStack.prototype.insertAfter = function (name, path, fn, options) {
-  var handler;
-  var index;
-
-  if (!(handler = this._stack[name]))
-    throw new Error("Couldn't find a handler named '" + name + "' on the path stack");
-
-  index = _.indexOf(this._stack, handler);
-  this.insertAt(index + 1, path, fn, options);
-  return this;
-};
-
-/**
  * Return a new MiddlewareStack comprised of this stack joined with other
- * stacks. Note the new stack will not have named handlers anymore. Only the
- * handlers are cloned but not the name=>handler mapping.
+ * stacks.
  */
 MiddlewareStack.prototype.concat = function (/* stack1, stack2, */) {
   var ret = new MiddlewareStack;

--- a/test/middleware_stack_test.js
+++ b/test/middleware_stack_test.js
@@ -19,19 +19,6 @@ Tinytest.add('MiddlewareStack - handler names and paths', function (test) {
   test.equal(handler.name, 'foo', 'name is "foo"');
 });
 
-Tinytest.add('MiddlewareStack - create and find by name', function (test) {
-  // basically just test that a handler gets created and keyed by name if thee's
-  // a name. Also test duplicate named handlers throws an error.
-
-  var stack = new Iron.MiddlewareStack;
-  stack._create('/items', function () {}, {name: 'items'});
-  test.isTrue(stack.findByName('items'));
-
-  test.throws(function () {
-    // same name
-    stack._create('/items', function () {}, {name: 'items'});
-  });
-});
 
 Tinytest.add('MiddlewareStack - push', function (test) {
   var stack = new Iron.MiddlewareStack;
@@ -49,24 +36,6 @@ Tinytest.add('MiddlewareStack - insertAt', function (test) {
   stack.push(fns[2]);
 
   stack.insertAt(1, fns[1]);
-  test.equal(stack._stack[1].handle, fns[1]);
-});
-
-Tinytest.add('MiddlewareStack - insertBefore', function (test) {
-  var stack = new Iron.MiddlewareStack;
-  var fns = [function one() {}, function two() {}, function three() {}];
-  stack.push(fns[0]);
-  stack.push(fns[2]);
-  stack.insertBefore('three', fns[1]);
-  test.equal(stack._stack[1].handle, fns[1]);
-});
-
-Tinytest.add('MiddlewareStack - insertAfter ', function (test) {
-  var stack = new Iron.MiddlewareStack;
-  var fns = [function one() {}, function two() {}, function three() {}];
-  stack.push(fns[0]);
-  stack.push(fns[2]);
-  stack.insertAfter('one', fns[1]);
   test.equal(stack._stack[1].handle, fns[1]);
 });
 
@@ -120,7 +89,7 @@ Tinytest.add('MiddlewareStack - dispatch iteration with this.next', function (te
 Tinytest.add('MiddlewareStack - dispatch callback', function (test) {
   var stack = new Iron.MiddlewareStack;
   var calls = [];
-  
+
   if (Meteor.isClient) {
     stack.push(function m1 () {
       calls.push('m1');
@@ -156,10 +125,10 @@ if (Meteor.isServer) {
   var Fiber = Npm.require('fibers');
   Tinytest.addAsync('MiddlewareStack - async next maintains fibers', function (test, done) {
     var envVar = new Meteor.EnvironmentVariable;
-    
+
     envVar.withValue(true, function () {
       var stack = new Iron.MiddlewareStack;
-      
+
       test.isTrue(envVar.getOrNullIfOutsideFiber());
       stack.push(function(req, res, next) {
         // break out of the current fiber
@@ -172,7 +141,7 @@ if (Meteor.isServer) {
         test.isTrue(envVar.getOrNullIfOutsideFiber());
         this.next();
       }, {where: 'server'});
-    
+
       stack.dispatch('/', {}, function () {
         test.isTrue(envVar.getOrNullIfOutsideFiber());
         done();


### PR DESCRIPTION
https://github.com/iron-meteor/iron-router/issues/1513

I can't find any code in `iron-router` that even uses any of the name-related API's. (`findByName`, `insertBefore` and `insertAfter`). 

But it is causing unusual breakages because names are auto-assigned based on the function name.
