### PR TITLE
Speedup finding a matching handler + workaround for 'Too many recursion'

### DIFF
--- a/lib/middleware_stack.js
+++ b/lib/middleware_stack.js
@@ -40,6 +40,22 @@ MiddlewareStack.prototype.findByName = function (name) {
   return this._stack[name];
 };
 
+/*
+ * Find the matching handler for a given URL through iteration (instead of recursion)
+ */
+MiddlewareStack.prototype.findByUrl = function dispatch (url, context) {
+    url = Url.normalize(url || '/');
+
+    for(var index=0; index < this._stack.length; index++) {
+        var handler = this._stack[index];
+        if (handler && handler.test(url, {method: context._method})) {
+            return index;
+        }
+    }
+
+    return 0;
+};
+
 /**
  * Push a new handler onto the stack.
  */
@@ -183,7 +199,9 @@ MiddlewareStack.prototype.dispatch = function dispatch (url, context, done) {
     }
   };
 
-  var index = 0;
+  // For performance reason. it's faster to iterate and find a matching handler on the URL
+  // It is also a workaround for a bug on Firefox 56 - Ubuntu 16 where too many routes cause "Too many recursion"
+  var index = this.findByUrl(url, context);
 
   var next = Meteor.bindEnvironment(function boundNext (err) {
     var handler = self._stack[index++];

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'iron:middleware-stack',
   summary: 'Client and server middleware support inspired by Connect.',
-  version: '1.1.0',
+  version: '1.1.1',
   git: 'https://github.com/iron-meteor/iron-middleware-stack'
 });
 


### PR DESCRIPTION
After updating to Meteor 1.5 (from 1.2), we found a bug no Ubuntu 16 + Firefox 56 where too many routes would cause "Too many recursion" in browser console.

This workaround find the matching URL through iteration (instead of calling next() through Meteor.bindEnvironment()).